### PR TITLE
systemd: Fix ExecStart binary target path

### DIFF
--- a/systemd/template-service.service
+++ b/systemd/template-service.service
@@ -4,7 +4,7 @@ Description=Template Service
 [Service]
 Type=simple
 PIDFile=/var/run/template-service.pid
-ExecStart=/bin/template-service
+ExecStart=/usr/bin/template-service
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
The ${CMAKE_INSTALL_BINDIR} CMake variable points to the /usr/bin path.
The binary target is installed in that path and the service file should
point to the same binary.

Signed-off-by: Gordan Markuš <gordan.markus@pelagicore.com>